### PR TITLE
feat: add --use-temp-dir flag for clean remote builds

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,16 @@ Options:
 
           Example: `--copy-back "./target/release/cuter-cat.png:.,*.bin:~/my-bins"`
 
+      --remote-path <REMOTE_PATH>
+          Specify the remote path behavior for builds
+
+          [default: mirror]
+
+          Possible values:
+          - mirror: Mirror the local directory structure on the remote server (default)
+          - tmp:    Use a temporary directory that is cleaned up after the build
+          - unique: Use a unique persistent directory in the user's home directory for each project
+
   -h, --help
           Print help (see a summary with '-h')
 


### PR DESCRIPTION
This PR introduces a new `--use-temp-dir` flag that allows users to create builds in temporary directories on the remote server instead of mirroring the local directory structure.

## Changes

- **New CLI flag**: `--use-temp-dir` option for cleaner build environments
- **Temporary directory management**: Uses `mktemp` to create unique temporary directories (e.g., `/tmp/crunch-<project-name>-XXXXXX`)
- **Smart rsync handling**: Adapts rsync behavior for pre-created temporary directories
- **Automatic cleanup**: Removes temporary directories after build completion
- **Documentation**: Updated README with usage examples and detailed explanation

## Benefits

- **Cleaner builds**: Avoids filesystem assumptions and potential conflicts
- **Isolated environments**: Each build gets its own temporary workspace
- **Flexibility**: Users can choose between directory mirroring (default) or temporary directories

## Trade-offs

- **Increased bandwidth**: Since temporary directories are created fresh each time, more data needs to be transferred compared to incremental syncing with mirrored directories

## Usage

```bash
crunch --use-temp-dir build --release
```

This feature is particularly useful for scenarios where you want guaranteed clean build environments or when the local directory structure might cause issues on the remote server.