### PR TITLE
Add workspace crunch config support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,13 +146,14 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "crunch-app"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "cargo_metadata",
  "clap",
  "env_logger",
  "log",
  "serde",
+ "toml",
  "which",
  "xdg",
 ]
@@ -187,6 +188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +202,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -207,6 +220,16 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "indexmap"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -352,6 +375,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +419,47 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-ident"
@@ -483,6 +556,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winsafe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crunch-app"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2021"
 description = "Turbocharge your Rust workflow with crunch"
 license = "MIT"
@@ -13,6 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 clap = { version = "4.5.21", default-features = true, features = ["derive"] }
 env_logger = "0.11.5"
 which = "8.0.0"
+toml = "0.8.19"
 
 [[bin]]
 name = "crunch"

--- a/readme.md
+++ b/readme.md
@@ -125,11 +125,6 @@ EXAMPLES:
 `crunch` automatically looks for `crunch.config.toml` in the Cargo workspace root and uses it for project-level defaults.
 
 On the first `crunch` run in a workspace, `crunch` creates this file automatically.
-
-```text
-New crunch workspace detected, initialised crunch config.
-```
-
 Precedence:
 
 1. `crunch.config.toml`

--- a/readme.md
+++ b/readme.md
@@ -130,8 +130,6 @@ Precedence:
 1. `crunch.config.toml`
 2. CLI flags
 
-For list options such as `exclude` and `copy_back`, CLI values replace the config file values.
-
 ```toml
 build_env = "RUST_BACKTRACE=1"
 exclude = ["target", ".git"]

--- a/readme.md
+++ b/readme.md
@@ -124,7 +124,7 @@ EXAMPLES:
 
 `crunch` automatically looks for `crunch.config.toml` in the Cargo workspace root and uses it for project-level defaults.
 
-On the first `crunch` run in a workspace, `crunch` creates this file automatically and prints:
+On the first `crunch` run in a workspace, `crunch` creates this file automatically.
 
 ```text
 New crunch workspace detected, initialised crunch config.

--- a/readme.md
+++ b/readme.md
@@ -112,7 +112,7 @@ Options:
           Print version
 
 CONFIG:
-    crunch automatically creates crunch.config.toml in the Cargo workspace root on first run.
+    crunch automatically creates crunch.toml in the Cargo workspace root on first run.
     CLI flags override config values.
 
 EXAMPLES:
@@ -122,12 +122,12 @@ EXAMPLES:
 
 ## Project Config
 
-`crunch` automatically looks for `crunch.config.toml` in the Cargo workspace root and uses it for project-level defaults.
+`crunch` automatically looks for `crunch.toml` in the Cargo workspace root and uses it for project-level defaults.
 
 On the first `crunch` run in a workspace, `crunch` creates this file automatically.
 Precedence:
 
-1. `crunch.config.toml`
+1. `crunch.toml`
 2. CLI flags
 
 ```toml

--- a/readme.md
+++ b/readme.md
@@ -82,16 +82,10 @@ Options:
   -e, --build-env <BUILD_ENV>
           Set remote environment variables. RUST_BACKTRACE, CC, LIB, etc
 
-          [default: RUST_BACKTRACE=1]
-
       --exclude <EXCLUDE>
           Path or directory to exclude from the remote server transfer. Specify multiple entries using delimiter ','.
 
-          By default the `target` and `.git` directories are excluded.
-
           Example: `--exclude "target,.git,cat.png,*.lock,mocks/**/*.db"`
-
-          [default: target,.git]
 
       --post-cargo <POST_CARGO>
           A command to execute on the machine after the cargo command has finished executing.
@@ -106,8 +100,6 @@ Options:
       --remote-path <REMOTE_PATH>
           Specify the remote path behavior for builds
 
-          [default: mirror]
-
           Possible values:
           - mirror: Mirror the local directory structure on the remote server (default)
           - tmp:    Use a temporary directory that is cleaned up after the build
@@ -119,9 +111,38 @@ Options:
   -V, --version
           Print version
 
+CONFIG:
+    crunch automatically creates crunch.config.toml in the Cargo workspace root on first run.
+    CLI flags override config values.
+
 EXAMPLES:
     crunch -e RUST_LOG=debug check --all-features --all-targets
     crunch test -- --nocapture
+```
+
+## Project Config
+
+`crunch` automatically looks for `crunch.config.toml` in the Cargo workspace root and uses it for project-level defaults.
+
+On the first `crunch` run in a workspace, `crunch` creates this file automatically and prints:
+
+```text
+New crunch workspace detected, initialised crunch config.
+```
+
+Precedence:
+
+1. `crunch.config.toml`
+2. CLI flags
+
+For list options such as `exclude` and `copy_back`, CLI values replace the config file values.
+
+```toml
+build_env = "RUST_BACKTRACE=1"
+exclude = ["target", ".git"]
+post_cargo = "cd target/release && profile my-binary"
+copy_back = ["./target/release/cuter-cat.png:."]
+remote_path = "mirror"
 ```
 
 ## `cargo-remote`

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,342 @@
+use cargo_metadata::camino::{Utf8Path, Utf8PathBuf};
+use clap::{Parser, ValueEnum};
+use serde::Deserialize;
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+};
+
+pub const CONFIG_FILE_NAME: &str = "crunch.config.toml";
+
+const DEFAULT_CONFIG_TEMPLATE: &str = r#"# Project-level defaults for crunch.
+# CLI flags override values from this file.
+# This file is discovered from the Cargo workspace root.
+
+# Environment variables exported before the remote cargo command runs.
+build_env = "RUST_BACKTRACE=1"
+
+# Paths or glob patterns to exclude when syncing the project to the remote host.
+exclude = ["target", ".git"]
+
+# Files or directories to copy back after the remote command finishes.
+# Each entry is in the form "source:destination".
+copy_back = []
+
+# Where crunch should place the project on the remote server.
+# Options:
+# - "mirror": mirror the local absolute path on the remote machine
+# - "tmp": create a temporary directory and remove it afterwards
+# - "unique": store the project under ~/crunch-builds/<name>-<hash>
+remote_path = "mirror"
+
+# Optional command to run on the remote machine after cargo finishes.
+# Example:
+# post_cargo = "cd target/release && profile my-binary"
+"#;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RemotePathBehavior {
+    /// Mirror the local directory structure on the remote server.
+    Mirror,
+    /// Create a directory in /tmp that is cleaned up when crunch finishes.
+    Tmp,
+    /// Use ~/crunch-builds.
+    Unique,
+}
+
+#[derive(Parser, Debug)]
+#[command(
+    version,
+    about,
+    trailing_var_arg = true,
+    after_long_help = "CONFIG:\n    crunch automatically creates crunch.config.toml in the Cargo workspace root on first run.\n    CLI flags override config values.\n\nEXAMPLES:\n    crunch -e RUST_LOG=debug check --all-features --all-targets\n    crunch test -- --nocapture"
+)]
+pub struct CliArgs {
+    /// Set remote environment variables. RUST_BACKTRACE, CC, LIB, etc.
+    #[arg(short = 'e', long)]
+    pub build_env: Option<String>,
+
+    /// Path or directory to exclude from the remote server transfer.
+    /// Specify multiple entries using delimiter ','.
+    ///
+    /// Example: `--exclude "target,.git,cat.png,*.lock,mocks/**/*.db"`
+    #[arg(long = "exclude", value_delimiter = ',')]
+    pub exclude: Option<Vec<String>>,
+
+    /// A command to execute on the machine after the cargo command has finished executing.
+    ///
+    /// Example: `--post-cargo "cd target/release && profile my-binary"`
+    #[arg(long = "post-cargo")]
+    pub post_cargo: Option<String>,
+
+    /// Path or directory to sync back from the remote server after all other work has been done.
+    /// Each entry should be in the format `source:destination`. Specify multiple entries using delimiter ','.
+    ///
+    /// Example: `--copy-back "./target/release/cuter-cat.png:.,*.bin:~/my-bins"`
+    #[arg(long = "copy-back", value_delimiter = ',')]
+    pub copy_back: Option<Vec<String>>,
+
+    /// Where crunch should place the project on the remote server.
+    #[arg(long = "remote-path")]
+    pub remote_path: Option<RemotePathBehavior>,
+
+    /// The cargo command to execute
+    ///
+    /// Example: `build --release`
+    #[arg(required = true, num_args = 1..)]
+    pub command: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CrunchConfig {
+    build_env: String,
+    exclude: Vec<String>,
+    #[serde(default)]
+    post_cargo: Option<String>,
+    #[serde(default)]
+    copy_back: Vec<String>,
+    remote_path: RemotePathBehavior,
+}
+
+#[derive(Debug)]
+pub struct ResolvedArgs {
+    pub build_env: String,
+    pub exclude: Vec<String>,
+    pub post_cargo: Option<String>,
+    pub copy_back: Vec<String>,
+    pub remote_path: RemotePathBehavior,
+    pub command: Vec<String>,
+}
+
+fn config_path(workspace_root: &Utf8Path) -> Utf8PathBuf {
+    workspace_root.join(CONFIG_FILE_NAME)
+}
+
+fn parse_config(contents: &str) -> Result<CrunchConfig, toml::de::Error> {
+    toml::from_str(contents)
+}
+
+fn write_default_config(path: &Utf8Path) -> Result<(), String> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path.as_std_path())
+        .map_err(|error| format!("Failed to create config '{}': {}", path, error))?;
+
+    file.write_all(DEFAULT_CONFIG_TEMPLATE.as_bytes())
+        .map_err(|error| format!("Failed to write config '{}': {}", path, error))
+}
+
+pub fn ensure_config_exists(workspace_root: &Utf8Path) -> Result<bool, String> {
+    let path = config_path(workspace_root);
+    if path.exists() {
+        return Ok(false);
+    }
+
+    write_default_config(path.as_ref())?;
+    Ok(true)
+}
+
+fn load_config(workspace_root: &Utf8Path) -> Result<CrunchConfig, String> {
+    let path = config_path(workspace_root);
+    let contents = fs::read_to_string(path.as_std_path())
+        .map_err(|error| format!("Failed to read config '{}': {}", path, error))?;
+
+    parse_config(&contents).map_err(|error| format!("Failed to parse config '{}': {}", path, error))
+}
+
+fn merge_args(cli: CliArgs, config: CrunchConfig) -> ResolvedArgs {
+    ResolvedArgs {
+        build_env: cli.build_env.unwrap_or(config.build_env),
+        exclude: cli.exclude.unwrap_or(config.exclude),
+        post_cargo: cli.post_cargo.or(config.post_cargo),
+        copy_back: cli.copy_back.unwrap_or(config.copy_back),
+        remote_path: cli.remote_path.unwrap_or(config.remote_path),
+        command: cli.command,
+    }
+}
+
+pub fn resolve_args(cli: CliArgs, workspace_root: &Utf8Path) -> Result<ResolvedArgs, String> {
+    let config = load_config(workspace_root)?;
+    Ok(merge_args(cli, config))
+}
+
+pub fn parse_copy_back_pairs(entries: &[String]) -> Result<Vec<(String, String)>, String> {
+    entries
+        .iter()
+        .map(|entry| {
+            let mut parts = entry.splitn(2, ':');
+            match (parts.next(), parts.next()) {
+                (Some(source), Some(dest)) => Ok((source.to_string(), dest.to_string())),
+                _ => Err(format!("Invalid format for --copy-back entry: {entry}")),
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+fn test_cli_args() -> CliArgs {
+    CliArgs {
+        build_env: None,
+        exclude: None,
+        post_cargo: None,
+        copy_back: None,
+        remote_path: None,
+        command: vec!["build".to_string()],
+    }
+}
+
+#[cfg(test)]
+fn unique_temp_workspace() -> Utf8PathBuf {
+    let unique_dir = format!(
+        "crunch-config-test-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let temp_dir = std::env::temp_dir().join(unique_dir);
+    fs::create_dir_all(&temp_dir).unwrap();
+    Utf8PathBuf::from_path_buf(temp_dir).unwrap()
+}
+
+#[test]
+fn parse_config_works() {
+    let config = parse_config(
+        r#"
+build_env = "RUST_LOG=debug"
+exclude = ["dist"]
+post_cargo = "echo done"
+copy_back = ["target/release/app:./bin"]
+remote_path = "unique"
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(config.build_env, "RUST_LOG=debug");
+    assert_eq!(config.exclude, vec!["dist".to_string()]);
+    assert_eq!(config.post_cargo.as_deref(), Some("echo done"));
+    assert_eq!(
+        config.copy_back,
+        vec!["target/release/app:./bin".to_string()]
+    );
+    assert_eq!(config.remote_path, RemotePathBehavior::Unique);
+}
+
+#[test]
+fn parse_config_rejects_unknown_fields() {
+    let error = parse_config("unknown = true").unwrap_err();
+
+    assert!(error.to_string().contains("unknown field `unknown`"));
+}
+
+#[test]
+fn parse_config_requires_core_fields() {
+    let error = parse_config("exclude = [\"target\"]\nremote_path = \"mirror\"").unwrap_err();
+
+    assert!(error.to_string().contains("missing field `build_env`"));
+}
+
+#[test]
+fn resolve_args_uses_config_when_cli_is_missing() {
+    let args = merge_args(
+        test_cli_args(),
+        CrunchConfig {
+            build_env: "RUST_LOG=debug".to_string(),
+            exclude: vec!["dist".to_string()],
+            post_cargo: Some("echo done".to_string()),
+            copy_back: vec!["target/release/app:./bin".to_string()],
+            remote_path: RemotePathBehavior::Unique,
+        },
+    );
+
+    assert_eq!(args.build_env, "RUST_LOG=debug");
+    assert_eq!(args.exclude, vec!["dist".to_string()]);
+    assert_eq!(args.post_cargo.as_deref(), Some("echo done"));
+    assert_eq!(args.copy_back, vec!["target/release/app:./bin".to_string()]);
+    assert_eq!(args.remote_path, RemotePathBehavior::Unique);
+}
+
+#[test]
+fn resolve_args_prefers_cli_over_config() {
+    let mut cli = test_cli_args();
+    cli.build_env = Some("RUST_LOG=trace".to_string());
+    cli.post_cargo = Some("echo cli".to_string());
+    cli.remote_path = Some(RemotePathBehavior::Tmp);
+
+    let args = merge_args(
+        cli,
+        CrunchConfig {
+            build_env: "RUST_LOG=debug".to_string(),
+            exclude: vec!["dist".to_string()],
+            post_cargo: Some("echo config".to_string()),
+            copy_back: vec!["target/release/app:./bin".to_string()],
+            remote_path: RemotePathBehavior::Unique,
+        },
+    );
+
+    assert_eq!(args.build_env, "RUST_LOG=trace");
+    assert_eq!(args.post_cargo.as_deref(), Some("echo cli"));
+    assert_eq!(args.remote_path, RemotePathBehavior::Tmp);
+}
+
+#[test]
+fn resolve_args_replaces_config_lists_when_cli_sets_them() {
+    let mut cli = test_cli_args();
+    cli.exclude = Some(vec!["cli-only".to_string()]);
+    cli.copy_back = Some(vec!["remote:local".to_string()]);
+
+    let args = merge_args(
+        cli,
+        CrunchConfig {
+            build_env: "RUST_BACKTRACE=1".to_string(),
+            exclude: vec!["config-only".to_string()],
+            post_cargo: None,
+            copy_back: vec!["config:dest".to_string()],
+            remote_path: RemotePathBehavior::Mirror,
+        },
+    );
+
+    assert_eq!(args.exclude, vec!["cli-only".to_string()]);
+    assert_eq!(args.copy_back, vec!["remote:local".to_string()]);
+}
+
+#[test]
+fn config_path_uses_workspace_root() {
+    let path = config_path(Utf8Path::new("/tmp/workspace"));
+
+    assert_eq!(path, Utf8PathBuf::from("/tmp/workspace/crunch.config.toml"));
+}
+
+#[test]
+fn ensure_config_exists_creates_default_config_once() {
+    let workspace_root = unique_temp_workspace();
+
+    assert!(ensure_config_exists(workspace_root.as_ref()).unwrap());
+    assert!(!ensure_config_exists(workspace_root.as_ref()).unwrap());
+
+    let config_contents =
+        fs::read_to_string(workspace_root.join(CONFIG_FILE_NAME).as_std_path()).unwrap();
+    assert_eq!(config_contents, DEFAULT_CONFIG_TEMPLATE);
+
+    fs::remove_dir_all(workspace_root.as_std_path()).unwrap();
+}
+
+#[test]
+fn parse_copy_back_pairs_works() {
+    let pairs = parse_copy_back_pairs(&["remote/path:./local".to_string()]).unwrap();
+
+    assert_eq!(
+        pairs,
+        vec![("remote/path".to_string(), "./local".to_string())]
+    );
+}
+
+#[test]
+fn parse_copy_back_pairs_rejects_invalid_entries() {
+    let error = parse_copy_back_pairs(&["remote-only".to_string()]).unwrap_err();
+
+    assert_eq!(error, "Invalid format for --copy-back entry: remote-only");
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use std::{
     io::Write,
 };
 
-pub const CONFIG_FILE_NAME: &str = "crunch.config.toml";
+pub const CONFIG_FILE_NAME: &str = "crunch.toml";
 
 const DEFAULT_CONFIG_TEMPLATE: &str = r#"# Project-level defaults for crunch.
 # CLI flags override values from this file.
@@ -50,7 +50,7 @@ pub enum RemotePathBehavior {
     version,
     about,
     trailing_var_arg = true,
-    after_long_help = "CONFIG:\n    crunch automatically creates crunch.config.toml in the Cargo workspace root on first run.\n    CLI flags override config values.\n\nEXAMPLES:\n    crunch -e RUST_LOG=debug check --all-features --all-targets\n    crunch test -- --nocapture"
+    after_long_help = "CONFIG:\n    crunch automatically creates crunch.toml in the Cargo workspace root on first run.\n    CLI flags override config values.\n\nEXAMPLES:\n    crunch -e RUST_LOG=debug check --all-features --all-targets\n    crunch test -- --nocapture"
 )]
 pub struct CliArgs {
     /// Set remote environment variables. RUST_BACKTRACE, CC, LIB, etc.
@@ -307,7 +307,7 @@ fn resolve_args_replaces_config_lists_when_cli_sets_them() {
 fn config_path_uses_workspace_root() {
     let path = config_path(Utf8Path::new("/tmp/workspace"));
 
-    assert_eq!(path, Utf8PathBuf::from("/tmp/workspace/crunch.config.toml"));
+    assert_eq!(path, Utf8PathBuf::from("/tmp/workspace/crunch.toml"));
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,13 @@
 //!
 //! crunch seamlessly integrates cutting-edge hardware into your local development environment.
 
+mod config;
+
+use crate::config::{
+    ensure_config_exists, parse_copy_back_pairs, resolve_args, CliArgs, RemotePathBehavior,
+};
 use cargo_metadata::camino::Utf8PathBuf;
-use clap::{Parser, ValueEnum};
+use clap::Parser;
 use log::{debug, error, info};
 use std::{
     hash::{DefaultHasher, Hash, Hasher},
@@ -23,71 +28,6 @@ pub struct Remote {
     pub env: String,
 }
 
-#[derive(Debug, Clone, ValueEnum)]
-enum RemotePathBehavior {
-    /// Mirror the local directory structure on the remote server.
-    Mirror,
-    /// Create a directory in /tmp that is cleaned up when crunch finishes.
-    Tmp,
-    /// Use ~/crunch-builds.
-    Unique,
-}
-
-#[derive(Parser, Debug)]
-#[command(
-    version,
-    about,
-    trailing_var_arg = true,
-    after_long_help = "EXAMPLES:\n    crunch -e RUST_LOG=debug check --all-features --all-targets\n    crunch test -- --nocapture"
-)]
-struct Args {
-    /// Set remote environment variables. RUST_BACKTRACE, CC, LIB, etc.
-    #[arg(
-        short = 'e',
-        long,
-        required = false,
-        default_value = "RUST_BACKTRACE=1"
-    )]
-    build_env: String,
-
-    /// Path or directory to exclude from the remote server transfer.
-    /// Specify multiple entries using delimiter ','.
-    ///
-    /// By default the `target` and `.git` directories are excluded.
-    ///
-    /// Example: `--exclude "target,.git,cat.png,*.lock,mocks/**/*.db"`
-    #[arg(
-        long = "exclude",
-        required = false,
-        value_delimiter = ',',
-        default_value = "target,.git"
-    )]
-    exclude: Vec<String>,
-
-    /// A command to execute on the machine after the cargo command has finished executing.
-    ///
-    /// Example: `--post-cargo "cd target/release && profile my-binary"`
-    #[arg(long = "post-cargo", required = false)]
-    post_cargo: Option<String>,
-
-    /// Path or directory to sync back from the remote server after all other work has been done.
-    /// Each entry should be in the format `source:destination`. Specify multiple entries using delimiter ','.
-    ///
-    /// Example: `--copy-back "./target/release/cuter-cat.png:.,*.bin:~/my-bins"`
-    #[arg(long = "copy-back", required = false, value_delimiter = ',')]
-    copy_back: Vec<String>,
-
-    /// Where crunch should place the project on the remote server.
-    #[arg(long = "remote-path", required = false, default_value = "mirror")]
-    remote_path: RemotePathBehavior,
-
-    /// The cargo command to execute
-    ///
-    /// Example: `build --release`
-    #[arg(required = true, num_args = 1..)]
-    command: Vec<String>,
-}
-
 fn uid_from_path(path: &Utf8PathBuf) -> u64 {
     let mut hasher = DefaultHasher::new();
     path.as_str().hash(&mut hasher);
@@ -99,27 +39,19 @@ fn main() {
         .filter_level(log::LevelFilter::Info)
         .init();
 
-    let args = Args::parse();
-    debug!("{:?}", &args);
+    let cli_args = CliArgs::parse();
+    debug!("{:?}", &cli_args);
 
-    let copy_back_pairs: Vec<(String, String)> = args
-        .copy_back
-        .into_iter()
-        .filter_map(|entry| {
-            let mut parts = entry.splitn(2, ':');
-            match (parts.next(), parts.next()) {
-                (Some(source), Some(dest)) => Some((source.to_string(), dest.to_string())),
-                _ => {
-                    panic!("Invalid format for --copy-back entry: {entry}");
-                }
-            }
-        })
-        .collect();
+    let manifest_path = extract_manifest_path(&cli_args.command);
 
     // Run it once redirecting logs to terminal to ensure if something needs to be installed, user
     // sees it.
-    Command::new("cargo")
-        .args(["metadata", "--no-deps", "--format-version", "1"])
+    let mut metadata_probe = Command::new("cargo");
+    metadata_probe.args(["metadata", "--no-deps", "--format-version", "1"]);
+    if let Some(manifest_path) = manifest_path.as_ref() {
+        metadata_probe.arg("--manifest-path").arg(manifest_path);
+    }
+    metadata_probe
         .stderr(Stdio::inherit())
         .output()
         .unwrap_or_else(|e| {
@@ -128,11 +60,28 @@ fn main() {
         });
 
     // Now run it again to get the workspace_root.
-    let manifest_path = extract_manifest_path(&args.command).unwrap_or("Cargo.toml".to_string());
     let mut metadata_cmd = cargo_metadata::MetadataCommand::new();
-    metadata_cmd.manifest_path(manifest_path).no_deps();
+    metadata_cmd.no_deps();
+    if let Some(manifest_path) = manifest_path.as_ref() {
+        metadata_cmd.manifest_path(manifest_path);
+    }
     let project_metadata = metadata_cmd.exec().unwrap();
     let project_dir = project_metadata.workspace_root;
+    if ensure_config_exists(project_dir.as_ref()).unwrap_or_else(|message| {
+        error!("{}", message);
+        exit(-8);
+    }) {
+        println!("New crunch workspace detected, initialised crunch config.");
+    }
+    let args = resolve_args(cli_args, project_dir.as_ref()).unwrap_or_else(|message| {
+        error!("{}", message);
+        exit(-8);
+    });
+    debug!("{:?}", &args);
+    let copy_back_pairs = parse_copy_back_pairs(&args.copy_back).unwrap_or_else(|message| {
+        error!("{}", message);
+        exit(-9);
+    });
 
     let remote = Remote {
         name: "crunch".to_string(),
@@ -185,9 +134,7 @@ fn main() {
         .arg("--compress")
         .arg("-e")
         .arg(format!("ssh -p {}", remote.ssh_port))
-        .arg("--info=progress2")
-        .arg("--exclude")
-        .arg("target");
+        .arg("--info=progress2");
 
     args.exclude.iter().for_each(|exclude| {
         rsync_to.arg("--exclude").arg(exclude);


### PR DESCRIPTION
Closes #3 
- add project-level `crunch.config.toml` support, including a dedicated config module and CLI/config merge behavior so repeated flags can live in the workspace
- auto-create a commented `crunch.config.toml` on the first `crunch` run in a workspace and require core defaults like `build_env`, `exclude`, and `remote_path` to come from that file
- update the README/help text, bump the crate version to `0.0.14`, and add tests covering config parsing, precedence, and first-run config creation
