### PR TITLE
Propagate the remote cargo exit code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "crunch-app"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "cargo_metadata",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crunch-app"
-version = "0.0.15"
+version = "0.0.16"
 edition = "2021"
 description = "Turbocharge your Rust workflow with crunch"
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,10 @@ fn main() {
     if args.quiet {
         remote_build.args(["-o", "LogLevel=ERROR"]);
     }
-    remote_build
+    // `ssh -t` exits with the remote command's own status, so this carries
+    // cargo's exit code. Hold on to it and replay it as our own exit code at
+    // the end of main, after copy-back and cleanup have had their turn.
+    let remote_status = remote_build
         .arg("-t")
         .arg(&build_server)
         .arg(command)
@@ -197,7 +200,8 @@ fn main() {
         .unwrap_or_else(|e| {
             error!("Failed to run cargo command remotely (error: {})", e);
             exit(-5);
-        });
+        })
+        .status;
 
     if !copy_back_pairs.is_empty() {
         info!("Transferring artifacts back to the local machine.");
@@ -308,6 +312,17 @@ fn main() {
                 debug!("Warning: Could not run cleanup command (error: {})", e);
             }
         }
+    }
+
+    // Surface a failed cargo run to our caller. Without this every crunch
+    // invocation exits 0, so `crunch test && ...`, CI steps, and hooks all read
+    // a failing build as a passing one.
+    //
+    // ssh reports its own connection failures as 255, which is indistinguishable
+    // from a remote process that genuinely exited 255. cargo does not use 255,
+    // so treating it as failure is right either way.
+    if !remote_status.success() {
+        exit(remote_status.code().unwrap_or(-5));
     }
 }
 


### PR DESCRIPTION
`crunch` discarded the `Output` of the remote `ssh` invocation, silently breaking anything that checks the exit status.